### PR TITLE
fix overflow problem on getCurrentTime

### DIFF
--- a/tasks/BaseTask.cpp
+++ b/tasks/BaseTask.cpp
@@ -38,9 +38,8 @@ base::Time BaseTask::getSimTime() const
 
 base::Time BaseTask::getCurrentTime(gazebo::msgs::Time sim_timestamp) const
 {
-    return getCurrentTime(base::Time::fromMicroseconds(
-                sim_timestamp.sec() * 1000000 + sim_timestamp.nsec() / 1000)
-            );
+    return getCurrentTime(base::Time::fromSeconds(sim_timestamp.sec())+
+            base::Time::fromMicroseconds(sim_timestamp.nsec() / 1000));
 }
 
 base::Time BaseTask::getCurrentTime(base::Time sim_timestamp) const


### PR DESCRIPTION
The way it was implemented was leading to overflow, making `sim_timestamp` on Line:45 be negative. It was impacting the timestamp of sensors such as GPS and IMU, making them delayed by some hours.

It caused  "velocity provider" to discard the samples and go to CRITICAL_ALIGNMENT_FAILURE.