### PR TITLE
imu: allow changing the IMU reference pose

### DIFF
--- a/rock_gazebo.orogen
+++ b/rock_gazebo.orogen
@@ -127,6 +127,9 @@ task_context "ImuTask" do
     # The name of the world frame'
     property('world_frame', '/std/string', 'imu_world')
 
+    # The reference of the orientation samples
+    property 'reference', '/rock_gazebo/IMUReference', 'REFERENCE_INITIAL_POSE'
+
     # Provides orientation samples reported by the IMU sensor.'
     output_port('orientation_samples', '/base/samples/RigidBodyState')
 

--- a/rock_gazeboTypes.hpp
+++ b/rock_gazeboTypes.hpp
@@ -9,6 +9,12 @@
 
 namespace rock_gazebo
 {
+    enum IMUReference {
+        REFERENCE_INITIAL_POSE,
+        REFERENCE_HORIZONTAL_PLANE,
+        REFERENCE_ABSOLUTE
+    };
+
     struct LinkExport {
         // The port name
         std::string port_name;

--- a/tasks/ImuTask.hpp
+++ b/tasks/ImuTask.hpp
@@ -113,8 +113,11 @@ namespace rock_gazebo{
 
         void readInput( ConstIMUPtr &imuMsg);
 
+    protected:
+        void setGazeboModel(ModelPtr model, sdf::ElementPtr sdfSensor);
     private:
         typedef std::vector<std::pair<base::samples::RigidBodyState, base::samples::IMUSensors>> Samples;
+        ignition::math::Quaterniond initialOrientation;
         Samples samples;
     };
 }

--- a/tasks/SensorTask.cpp
+++ b/tasks/SensorTask.cpp
@@ -73,7 +73,8 @@ void SensorTask::setGazeboModel(ModelPtr model, sdf::ElementPtr sdfSensor)
 
     sdf::ElementPtr sdfLink = sdfSensor->GetParent();
     this->gazeboModel = model;
-    this->sdfSensor = sdfSensor;
+    this->sdfSensor   = sdfSensor;
+    this->gazeboLink  = model->GetChildLink(sdfLink->Get<string>("name"));
 
     sensorFullName =
         getWorldName() + "::" +

--- a/tasks/SensorTask.hpp
+++ b/tasks/SensorTask.hpp
@@ -106,6 +106,7 @@ namespace rock_gazebo{
         void cleanupHook();
 
         typedef gazebo::physics::ModelPtr ModelPtr;
+        typedef gazebo::physics::LinkPtr LinkPtr;
         virtual void setGazeboModel(ModelPtr model, sdf::ElementPtr sdfSensor);
 
     protected:
@@ -117,6 +118,7 @@ namespace rock_gazebo{
         }
 
         ModelPtr gazeboModel;
+        LinkPtr gazeboLink;
         sdf::ElementPtr sdfSensor;
         gazebo::transport::SubscriberPtr subscriber;
         gazebo::transport::NodePtr node;


### PR DESCRIPTION
By default, a Gazebo IMU actually gives the transformation between
its initial pose and the current pose. This is .... not-so expected
for most of the IMUs (one would at least expect that the IMU would
correct for gravity).

In any case, provide some control over that, allowing to either retain
the default (and current) configuration, or use
REFERENCE_HORIZONTAL_PLANE to correct for gravity but keep the offset
in heading, or REFERENCE_ABSOLUTE to provide the absolute orientation.
to keep t