### PR TITLE
add support to rename the task based on the gazebo plugin name

### DIFF
--- a/tasks/ThrusterTask.cpp
+++ b/tasks/ThrusterTask.cpp
@@ -96,11 +96,11 @@ void ThrusterTask::cleanupHook()
     node->Fini();
 }
 
-void ThrusterTask::setGazeboModel( ModelPtr model )
+void ThrusterTask::setGazeboModel( std::string const& pluginName, ModelPtr model )
 {
     string worldName = GzGet((*(model->GetWorld())), Name, ());
 
-    string taskName = "gazebo:" + worldName + ":" + model->GetName() + ":gazebo_thruster";
+    string taskName = "gazebo:" + worldName + ":" + model->GetName() + ":" + pluginName;
     provides()->setName(taskName);
     _name.set(taskName);
 

--- a/tasks/ThrusterTask.hpp
+++ b/tasks/ThrusterTask.hpp
@@ -27,7 +27,7 @@ namespace rock_gazebo {
         void stopHook();
         void cleanupHook();
 
-        void setGazeboModel( ModelPtr );
+        void setGazeboModel( std::string const& pluginName, ModelPtr );
 
     private:
         std::string topicName;


### PR DESCRIPTION
The Syskit support always assumed the task was named on the basis
of the plugin name, but the C++ integration was not actually doing
so (which would lead to collisions if there was the same plugin
spawned more than once in any given model).

This was confusing as one would basically have to make sure the plugin
name was set to whatever the task was expecting.