### PR TITLE
fix joint name validation

### DIFF
--- a/rock_gazebo.orogen
+++ b/rock_gazebo.orogen
@@ -1,32 +1,34 @@
-name "rock_gazebo"
-import_types_from "base"
-import_types_from "rock_gazeboTypes.hpp"
-import_types_from "gps_base"
+# frozen_string_literal: true
 
-using_library "gazebo"
-using_library "gazebo_thruster"
+name 'rock_gazebo'
+import_types_from 'base'
+import_types_from 'rock_gazeboTypes.hpp'
+import_types_from 'gps_base'
+
+using_library 'gazebo'
+using_library 'gazebo_thruster'
 
 # Representation of a gazebo World object
-task_context "WorldTask" do
+task_context 'WorldTask' do
     needs_configuration
 
     # The world full name
-    attribute "name", '/std/string'
+    attribute 'name', '/std/string'
 
     # The simulation time
     output_port 'time', 'base/Time'
 end
 
-task_context "BaseTask" do
+task_context 'BaseTask' do
     needs_configuration
 
     # Controls whether the components should use the simulation time (the
     # default) or wall-clock time
-    property "use_sim_time", "/bool", true
+    property 'use_sim_time', '/bool', true
 end
 
 # Representation of a gazebo Model object
-task_context "ModelTask", subclasses: 'BaseTask' do
+task_context 'ModelTask', subclasses: 'BaseTask' do
     needs_configuration
 
     # How long will the task consider that a value received on the joints_cmd
@@ -42,7 +44,7 @@ task_context "ModelTask", subclasses: 'BaseTask' do
     property 'wrench_command_timeout', '/base/Time'
 
     # The model full name
-    attribute "name", '/std/string'
+    attribute 'name', '/std/string'
 
     # The frame name for the model pose. It will, by default, be set to the
     # model's name (e.g. flat_fish)
@@ -58,72 +60,74 @@ task_context "ModelTask", subclasses: 'BaseTask' do
     property 'cov_orientation', '/base/Matrix3d'
     # The covariance matrix to be used as velocity covariance. Default is unset (NaN)
     property 'cov_velocity', '/base/Matrix3d'
-    # The covariance matrix to be used as angular velocity covariance. Default is unset (NaN)
+    # The covariance matrix to be used as angular velocity covariance. Default
+    # is unset (NaN)
     property 'cov_angular_velocity', '/base/Matrix3d'
 
-    property "exported_links", "std/vector<rock_gazebo/LinkExport>"
-    property "exported_joints", "std/vector<rock_gazebo/JointExport>"
+    property 'exported_links', 'std/vector<rock_gazebo/LinkExport>'
+    property 'exported_joints', 'std/vector<rock_gazebo/JointExport>'
+
 
     # The model's pose if one wants to "warp"
-    input_port 'model_pose', "/base/samples/RigidBodyState"
+    input_port 'model_pose', '/base/samples/RigidBodyState'
 
     # Joints input/output ports
-    input_port "joints_cmd", "/base/samples/Joints"
-    output_port "joints_samples", "/base/samples/Joints"
+    input_port 'joints_cmd', '/base/samples/Joints'
+    output_port 'joints_samples', '/base/samples/Joints'
     # Link export
-    dynamic_input_port /_wrench$/, '/base/samples/Wrench'
-    dynamic_output_port /.*/, '/base/samples/RigidBodyState'
-    dynamic_output_port /_acceleration$/, '/base/samples/RigidBodyAcceleration'
-    dynamic_input_port /_cmd$/, '/base/samples/Joints'
-    dynamic_output_port /_samples$/, '/base/samples/Joints'
+    dynamic_input_port(/_wrench$/, '/base/samples/Wrench')
+    dynamic_output_port(/.*/, '/base/samples/RigidBodyState')
+    dynamic_output_port(/_acceleration$/, '/base/samples/RigidBodyAcceleration')
+    dynamic_input_port(/_cmd$/, '/base/samples/Joints')
+    dynamic_output_port(/_samples$/, '/base/samples/Joints')
 
     exception_states 'INVALID_JOINT_COMMAND'
 end
 
-task_context "UnderwaterTask", subclasses: 'BaseTask' do
+task_context 'UnderwaterTask', subclasses: 'BaseTask' do
     needs_configuration
 
     exception_states 'NO_TOPIC_CONNECTION'
 
     # Plugin full name
-    attribute "name", "/std/string"
+    attribute 'name', '/std/string'
 
     # Water velocity input port
-    input_port "fluid_velocity", "/base/Vector3d"
+    input_port 'fluid_velocity', '/base/Vector3d'
 end
 
-task_context "ThrusterTask", subclasses: 'BaseTask' do
+task_context 'ThrusterTask', subclasses: 'BaseTask' do
     needs_configuration
 
     exception_states 'NO_TOPIC_CONNECTION', 'NO_JOINT_NAMES'
 
     # Thruster full name
-    attribute "name", "/std/string"
+    attribute 'name', '/std/string'
 
     # Thruster input port
-    input_port "thrusters_cmd", "/base/samples/Joints"
+    input_port 'thrusters_cmd', '/base/samples/Joints'
     # Thruster status port
-    output_port "joint_samples", "/base/samples/Joints"
+    output_port 'joint_samples', '/base/samples/Joints'
 end
 
-task_context "SensorTask", subclasses: 'BaseTask' do
+task_context 'SensorTask', subclasses: 'BaseTask' do
     abstract
 
     # The sensor's full name
-    attribute "name", "/std/string"
+    attribute 'name', '/std/string'
 end
 
-task_context "LaserScanTask", subclasses: 'SensorTask' do
+task_context 'LaserScanTask', subclasses: 'SensorTask' do
     # Laser line output port
-    output_port "laser_scan_samples", "/base/samples/LaserScan"
+    output_port 'laser_scan_samples', '/base/samples/LaserScan'
 end
 
-task_context "CameraTask", subclasses: 'SensorTask' do
+task_context 'CameraTask', subclasses: 'SensorTask' do
     # Camera output port
     output_port 'frame', ro_ptr('base::samples::frame::Frame')
 end
 
-task_context "ImuTask", subclasses: 'SensorTask' do
+task_context 'ImuTask', subclasses: 'SensorTask' do
     # The name of the frame attached to the IMU'
     property('imu_frame', '/std/string', 'imu')
 
@@ -146,7 +150,7 @@ task_context "ImuTask", subclasses: 'SensorTask' do
     output_port('imu_samples', '/base/samples/IMUSensors')
 end
 
-task_context "GPSTask", subclasses: 'SensorTask' do
+task_context 'GPSTask', subclasses: 'SensorTask' do
     # The name of the frame attached to the GPS'
     property('gps_frame', '/std/string', 'gps')
 
@@ -161,10 +165,10 @@ task_context "GPSTask", subclasses: 'SensorTask' do
     #
     # If you intend to compare true positions provided by ModelTask to things
     # that use the GPS, this must be false
-    property('use_proper_utm_conversion', "bool", false)
+    property('use_proper_utm_conversion', 'bool', false)
 
     # The raw GPS position
-    output_port "gps_solution", "gps_base/Solution"
+    output_port 'gps_solution', 'gps_base/Solution'
 
     # Computed UTM position
     output_port 'utm_samples', '/base/samples/RigidBodyState'
@@ -174,19 +178,19 @@ task_context "GPSTask", subclasses: 'SensorTask' do
 
     # UTM zone for conversion of WGS84 to UTM if use_proper_utm_conversion is
     # true
-    property("utm_zone", "int", 32)
+    property('utm_zone', 'int', 32)
 
     # UTM north for conversion of WGS84 to UTM if use_proper_utm_conversion is
     # true
-    property("utm_north", "bool", true)
+    property('utm_north', 'bool', true)
 
     # Origin in UTM coordinates, that is used for position readings if
     # use_proper_utm_conversion is true
-    property("nwu_origin", "/base/Position")
+    property('nwu_origin', '/base/Position')
 
     # Latitude of the origin if use_proper_utm_conversion is false
-    property('latitude_origin', "/base/Angle")
+    property('latitude_origin', '/base/Angle')
 
     # Longitude of the origin if use_proper_utm_conversion is false
-    property('longitude_origin', "/base/Angle")
+    property('longitude_origin', '/base/Angle')
 end

--- a/rock_gazebo.orogen
+++ b/rock_gazebo.orogen
@@ -37,6 +37,12 @@ task_context 'ModelTask', subclasses: 'BaseTask' do
     # Defaults to one second
     property 'joint_command_timeout', '/base/Time'
 
+    # Whether the main joints_cmd input should have its names validated or not
+    #
+    # This controls only joints_cmd. Individually exported sets of joints can
+    # have different settings
+    property 'ignore_joint_names', '/bool', false
+
     # How long will the task consider that a value received on a external link
     # wrench port is valid.
     #

--- a/rock_gazeboTypes.hpp
+++ b/rock_gazeboTypes.hpp
@@ -64,6 +64,13 @@ namespace rock_gazebo
         std::vector<std::string> joints;
         /** The period of update of the output port */
         base::Time port_period;
+        /** Whether to validate the names of the incoming joint commands,
+         * or just assume they are provided in the same order than \c joints
+         */
+        bool ignore_joint_names;
+
+        JointExport()
+            : ignore_joint_names(false) {}
     };
 }
 

--- a/tasks/ModelTask.cpp
+++ b/tasks/ModelTask.cpp
@@ -45,10 +45,12 @@ void ModelTask::setGazeboModel(WorldPtr _world,  ModelPtr _model)
     BaseTask::setGazeboWorld(_world);
     model = _model;
 
-    if (_model_frame.get().empty())
+    if (_model_frame.get().empty()) {
         _model_frame.set(_model->GetName());
-    if (_world_frame.get().empty())
+    }
+    if (_world_frame.get().empty()) {
         _world_frame.set(GzGet((*_world), Name, ()));
+    }
 }
 
 void ModelTask::InternalJointExport::addJoint(JointPtr joint, std::string name)
@@ -68,24 +70,28 @@ void ModelTask::setupJoints()
     // Setup a joint export for the "main" interface
     InternalJointExport main_joint_export;
     main_joint_export.permanent = true;
+    main_joint_export.ignore_joint_names = _ignore_joint_names.get();
     main_joint_export.in_port = &_joints_cmd;
     main_joint_export.out_port = &_joints_samples;
     for (auto const& joint : gazebo_joints)
     {
 #if GAZEBO_MAJOR_VERSION >= 6
-        if(joint->HasType(physics::Base::FIXED_JOINT))
+        if (joint->HasType(physics::Base::FIXED_JOINT))
         {
-            gzmsg << "ModelTask: ignore fixed joint: " << GzGet((*world), Name, ()) + "/" + model->GetName() +
-                "/" + joint->GetName() << endl;
+            gzmsg << "ModelTask: ignore fixed joint: "
+                  << GzGet((*world), Name, ())
+                  << "/" << model->GetName()
+                  << "/" << joint->GetName() << endl;
             continue;
         }
 #endif
-        gzmsg << "ModelTask: found joint: " << GzGet((*world), Name, ()) + "/" + model->GetName() +
-                "/" + joint->GetName() << endl;
+        gzmsg << "ModelTask: found joint (in/out): "
+              << GzGet((*world), Name, ())
+              << "/" << model->GetName()
+              << "/" << joint->GetName() << endl;
         main_joint_export.addJoint(joint, joint->GetScopedName());
     }
     exported_joints.push_back(main_joint_export);
-
 
     std::vector<JointExport> requested_exports =
         _exported_joints.get();
@@ -97,22 +103,30 @@ void ModelTask::setupJoints()
         InternalJointExport export_setup;
         for (auto const& gz_joint_name : export_request.joints)
         {
-            if (gz_joint_name.substr(0, prefix.size()) != prefix)
-            { gzthrow("ModelTask: the name of the exported joint " << gz_joint_name << " does not start with the expected prefix '" + prefix + "'"); }
+            if (gz_joint_name.substr(0, prefix.size()) != prefix) {
+                gzthrow("ModelTask: the name of the exported joint " << gz_joint_name
+                        << " does not start with the expected prefix '" + prefix + "'");
+            }
             string joint_name = gz_joint_name.substr(prefix.size(), std::string::npos);
 
             auto gz_joint = model->GetJoint(gz_joint_name);
-            if (!gz_joint || gz_joint->GetScopedName() != gz_joint_name)
-            { gzthrow("ModelTask: cannot find joint " << gz_joint_name << " requested in export, ModelTask expects a scoped name (i.e. including the enclosing model's name)"); }
-            else if(gz_joint->HasType(physics::Base::FIXED_JOINT))
-            { gzthrow("ModelTask: requesting to export joint " << gz_joint_name << " which is a fixed joint"); }
+            if (!gz_joint || gz_joint->GetScopedName() != gz_joint_name) {
+                gzthrow("ModelTask: cannot find joint " << gz_joint_name
+                        << " requested in export, ModelTask expects a scoped name "
+                        << "(i.e. including the enclosing model's name)");
+            }
+            else if (gz_joint->HasType(physics::Base::FIXED_JOINT)) {
+                gzthrow("ModelTask: requesting to export joint "
+                        << gz_joint_name << " which is a fixed joint");
+            }
 
             export_setup.addJoint(gz_joint, joint_name);
         }
 
         export_setup.port_period = export_request.port_period;
-        export_setup.in_port  = new JointsInputPort(export_request.port_name + "_cmd");
-        export_setup.out_port = new JointsOutputPort(export_request.port_name + "_samples");
+        export_setup.in_port = new JointsInputPort(export_request.port_name + "_cmd");
+        export_setup.out_port =
+            new JointsOutputPort(export_request.port_name + "_samples");
         ports()->addPort(*export_setup.in_port);
         ports()->addPort(*export_setup.out_port);
         exported_joints.push_back(export_setup);
@@ -252,24 +266,35 @@ void ModelTask::updateModelPose(base::Time const& time)
     rbs.sourceFrame = _model_frame.get();
     rbs.targetFrame = _world_frame.get();
     rbs.position = base::Vector3d(
-        model2world.Pos().X(),model2world.Pos().Y(),model2world.Pos().Z());
+        model2world.Pos().X(),
+        model2world.Pos().Y(),
+        model2world.Pos().Z()
+    );
     rbs.cov_position = _cov_position.get();
     rbs.orientation = base::Quaterniond(
-        model2world.Rot().W(),model2world.Rot().X(),model2world.Rot().Y(),model2world.Rot().Z() );
+        model2world.Rot().W(),
+        model2world.Rot().X(),
+        model2world.Rot().Y(),
+        model2world.Rot().Z()
+    );
     rbs.cov_orientation = _cov_orientation.get();
     rbs.velocity = base::Vector3d(
         model2world_vel.X(), model2world_vel.Y(), model2world_vel.Z());
     rbs.cov_velocity = _cov_velocity.get();
     rbs.angular_velocity = base::Vector3d(
-        model2world_angular_vel.X(), model2world_angular_vel.Y(), model2world_angular_vel.Z());
+        model2world_angular_vel.X(),
+        model2world_angular_vel.Y(),
+        model2world_angular_vel.Z()
+    );
     rbs.cov_angular_velocity = _cov_angular_velocity.get();
     _pose_samples.write(rbs);
 }
 
 void ModelTask::writeExportedJointSamples(base::Time const& time, InternalJointExport& exported_joint)
 {
-    if (time - exported_joint.joints_out.time < exported_joint.port_period)
+    if (time - exported_joint.joints_out.time < exported_joint.port_period) {
         return;
+    }
 
     size_t size = exported_joint.gazebo_joints.size();
     for (unsigned int i = 0; i < size; ++i)
@@ -290,44 +315,53 @@ void ModelTask::writeExportedJointSamples(base::Time const& time, InternalJointE
 
 void ModelTask::readExportedJointCmd(base::Time const& time, InternalJointExport& exported_joint)
 {
-    RTT::FlowStatus flow = exported_joint.in_port->read( exported_joint.joints_in );
+    RTT::FlowStatus flow = exported_joint.in_port->read(exported_joint.joints_in);
 
-    if (flow == RTT::NewData)
+    if (flow == RTT::NewData) {
         exported_joint.last_command = time;
-    else if (exported_joint.last_command.isNull())
+    }
+    else if (exported_joint.last_command.isNull()) {
         return;
-    else if (time - exported_joint.last_command >= _joint_command_timeout.get())
+    }
+    else if (time - exported_joint.last_command >= _joint_command_timeout.get()) {
         return;
+    }
 
     size_t size = exported_joint.gazebo_joints.size();
-    if (exported_joint.joints_in.elements.size() != size)
-    {
-        LOG_ERROR_S << "Received command with size " << exported_joint.joints_in.elements.size() << " expected " << size << std::endl;
+    if (exported_joint.joints_in.elements.size() != size) {
+        LOG_ERROR_S
+            << "Received command with size "
+            << exported_joint.joints_in.elements.size()
+            << " expected " << size << std::endl;
         return exception(INVALID_JOINT_COMMAND);
     }
 
-    for (unsigned int i = 0; i < size; ++i)
-    {
+    for (unsigned int i = 0; i < size; ++i) {
         base::JointState const& cmd   = exported_joint.joints_in.elements[i];
         std::string const& name       = exported_joint.joints_in.names[i];
         gazebo::physics::Joint& joint = *exported_joint.gazebo_joints[i];
         std::string const& expected_name = exported_joint.expected_names[i];
         if (expected_name != name)
-        {
-            LOG_ERROR_S << "Expected " << i << "th joint to be " << expected_name << " but it is " << name << std::endl;
+            LOG_ERROR_S
+                << "Expected " << i << "th joint to be "
+                << expected_name << " but it is " << name << std::endl;
             return exception(INVALID_JOINT_COMMAND);
         }
 
         // Apply effort to joint
-        if( cmd.isEffort() )
-            joint.SetForce(0, cmd.effort );
-        else if( cmd.isPosition() )
-            joint.SetPosition(0, cmd.position );
-        else if( cmd.isSpeed() )
-            joint.SetVelocity(0, cmd.speed );
-        else
-        {
-            LOG_ERROR_S << "Received command that is neither a pure effort, position or speed" << std::endl;
+        if (cmd.isEffort()) {
+            joint.SetForce(0, cmd.effort);
+        }
+        else if (cmd.isPosition()) {
+            joint.SetPosition(0, cmd.position);
+        }
+        else if (cmd.isSpeed()) {
+            joint.SetVelocity(0, cmd.speed);
+        }
+        else {
+            LOG_ERROR_S
+                << "Received command that is neither a pure effort, "
+                << "position or speed" << std::endl;
             return exception(INVALID_JOINT_COMMAND);
         }
     }

--- a/tasks/ModelTask.hpp
+++ b/tasks/ModelTask.hpp
@@ -75,6 +75,7 @@ namespace rock_gazebo {
             {
                 bool permanent;
                 base::Time port_period;
+                bool ignore_joint_names;
                 std::vector<JointPtr> gazebo_joints;
                 std::vector<std::string> expected_names;
 
@@ -100,8 +101,15 @@ namespace rock_gazebo {
             void setupLinks();
             void warpModel(base::samples::RigidBodyState const& modelPose);
             void updateLinks(base::Time const& time);
-            void writeExportedJointSamples(base::Time const& time, InternalJointExport& exported_joint);
-            void readExportedJointCmd(base::Time const& time, InternalJointExport& exported_joint);
+            void writeExportedJointSamples(
+                base::Time const& time, InternalJointExport& exported_joint
+            );
+            void readExportedJointCmd(
+                base::Time const& time, InternalJointExport& exported_joint
+            );
+            bool validateExportedJointCmd(
+                InternalJointExport const& exported_joint
+            ) const;
             void updateModelPose(base::Time const& time);
 
             std::string checkExportedLinkElements(std::string, std::string, std::string);

--- a/tasks/ModelTask.hpp
+++ b/tasks/ModelTask.hpp
@@ -1,13 +1,13 @@
 /* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
 //======================================================================================
-// Brazilian Institute of Robotics 
+// Brazilian Institute of Robotics
 // Authors: Thomio Watanabe
 // Date: December 2014
-//====================================================================================== 
+//======================================================================================
 #ifndef ROCK_GAZEBO_MODELTASK_TASK_HPP
 #define ROCK_GAZEBO_MODELTASK_TASK_HPP
 
-#include "rock_gazebo/ModelTaskBase.hpp"	
+#include "rock_gazebo/ModelTaskBase.hpp"
 #include <base/commands/Joints.hpp>
 #include <gazebo/physics/physics.hh>
 
@@ -20,7 +20,7 @@ namespace rock_gazebo {
             typedef gazebo::physics::ModelPtr ModelPtr;
             typedef gazebo::physics::JointPtr JointPtr;
             typedef gazebo::physics::LinkPtr LinkPtr;
-	        
+
         friend class ModelTaskBase;
         private:
             ModelPtr model;
@@ -125,9 +125,9 @@ namespace rock_gazebo {
 		     */
             ModelTask(std::string const& name = "gazebo::ModelTask");
 
-		    /** TaskContext constructor for ModelTask 
-		     * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices. 
-		     * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task. 
+		    /** TaskContext constructor for ModelTask
+		     * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices.
+		     * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task.
 		     * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
 		     */
             ModelTask(std::string const& name, RTT::ExecutionEngine* engine);


### PR DESCRIPTION
The current code was happily assuming that the `names` vector is of the
same size than the elements, which obviously could lead to OOB access.
Weirdly enough, on my dev machine, it would end up pointing to the
expected names (!) and pass the test. This is obviously not good.

Fix the whole validation routine, moving it to a separate method
that is called only for new elements (avoiding re-validating the
same command over and over again).

Also, add an `ignore_joint_names` flag to retain the "I don't use names"
behavior, but this time in a controlled manner.