### PR TITLE
add support to specify position offsets for exported joints

### DIFF
--- a/rock_gazeboTypes.hpp
+++ b/rock_gazeboTypes.hpp
@@ -62,6 +62,11 @@ namespace rock_gazebo
         /** The joints that will be exported
          */
         std::vector<std::string> joints;
+        /** Position offsets for each of the exported joint
+         *
+         * It either can be empty, or has to have the same size than \c joints
+         */
+        std::vector<double> position_offsets;
         /** The period of update of the output port */
         base::Time port_period;
         /** Whether to validate the names of the incoming joint commands,

--- a/tasks/ModelTask.hpp
+++ b/tasks/ModelTask.hpp
@@ -85,6 +85,8 @@ namespace rock_gazebo {
                 JointsOutputPort* out_port;
                 base::Time last_command;
 
+                std::vector<double> position_offsets;
+
                 InternalJointExport()
                     : permanent(false)
                     , in_port(nullptr)


### PR DESCRIPTION
It turns out that the initial_position SDF element is not handled
by Gazebo 9 to 11. So, joints are always at zero in their initial
position.

This is obviously suboptimal for a whole lot of joints, so support
having an offset applied in/out of gazebo