### PR TITLE
fix bridge between Gazebo callbacks and Rock ports

### DIFF
--- a/tasks/CameraTask.hpp
+++ b/tasks/CameraTask.hpp
@@ -27,7 +27,7 @@ namespace rock_gazebo{
         /** TaskContext constructor for CameraTask
          * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices.
          * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task.
-         * 
+         *
          */
         CameraTask(std::string const& name, RTT::ExecutionEngine* engine);
 
@@ -96,8 +96,8 @@ namespace rock_gazebo{
 
     private:
         void readInput( ConstImageStampedPtr &imageMsg);
-        bool bnew_data;
-        RTT::extras::ReadOnlyPointer<base::samples::frame::Frame> output_frame;	
+        bool hasNewSample;
+        RTT::extras::ReadOnlyPointer<base::samples::frame::Frame> output_frame;
     };
 }
 

--- a/tasks/GPSTask.hpp
+++ b/tasks/GPSTask.hpp
@@ -13,22 +13,26 @@
 namespace rock_gazebo{
 
     /*! \class GPSTask
-     * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
-     * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
-     * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
-     * 
+     * \brief The task context provides and requires services. It uses an
+     * ExecutionEngine to perform its functions. Essential interfaces are
+     * operations, data flow ports and properties. These interfaces have been
+     * defined using the oroGen specification. In order to modify the
+     * interfaces you should (re)use oroGen and rely on the associated
+     * workflow.
+     *
      * \details
      * The name of a TaskContext is primarily defined via:
-     \verbatim
-     deployment 'deployment_name'
-         task('custom_task_name','rock_gazebo::GPSTask')
-     end
-     \endverbatim
-     *  It can be dynamically adapted when the deployment is called with a prefix argument.
+     * \verbatim
+     * deployment 'deployment_name'
+     *     task('custom_task_name','rock_gazebo::GPSTask')
+     * end
+     * \endverbatim
+     * It can be dynamically adapted when the deployment is called with a
+     * prefix argument.
      */
     class GPSTask : public GPSTaskBase
     {
-	friend class GPSTaskBase;
+        friend class GPSTaskBase;
 
     private:
         gps_base::UTMConverter utm_converter;
@@ -36,29 +40,36 @@ namespace rock_gazebo{
         double deviationVertical;
         void setGazeboModel(ModelPtr model, sdf::ElementPtr sdfSensor);
 
-        std::vector<gps_base::Solution> solutions;
-        gazebo::common::SphericalCoordinates gazebo_spherical;
+        bool hasNewSample;
+        gps_base::Solution solution;
+        gazebo::common::SphericalCoordinates gazeboSpherical;
 
     protected:
         void readInput(ConstGPSPtr &msg);
 
     public:
         /** TaskContext constructor for GPSTask
-         * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
-         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
+         * \param name Name of the task. This name needs to be unique to make
+         *      it identifiable via nameservices.
+         * \param initial_state The initial TaskState of the TaskContext.
+         *      Default is Stopped state.
          */
         GPSTask(std::string const& name = "rock_gazebo::GPSTask");
 
         /** TaskContext constructor for GPSTask
-         * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices.
-         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task.
-         * 
+         * \param name Name of the task. This name needs to be unique to make
+         *      it identifiable for nameservices.
+         * \param engine
+         *      The RTT Execution engine to be used for this task, which serialises
+         *      the execution of all commands, programs, state machines and incoming
+         *      events for a task.
+         *
          */
         GPSTask(std::string const& name, RTT::ExecutionEngine* engine);
 
-        /** Default deconstructor of GPSTask
+        /** Default destructor of GPSTask
          */
-	~GPSTask();
+        ~GPSTask();
 
         /** This hook is called by Orocos when the state machine transitions
          * from PreOperational to Stopped. If it returns false, then the

--- a/tasks/ImuTask.hpp
+++ b/tasks/ImuTask.hpp
@@ -111,15 +111,14 @@ namespace rock_gazebo{
          */
         void cleanupHook();
 
-        void readInput( ConstIMUPtr &imuMsg);
+        void readInput(ConstIMUPtr &imuMsg);
 
     protected:
         void setGazeboModel(ModelPtr model, sdf::ElementPtr sdfSensor);
     private:
-        typedef std::vector<std::pair<base::samples::RigidBodyState, base::samples::IMUSensors>> Samples;
         ignition::math::Quaterniond initialOrientation;
         base::samples::RigidBodyState orientation;
-        Samples samples;
+        base::samples::IMUSensors imuSensors;
     };
 }
 

--- a/tasks/LaserScanTask.hpp
+++ b/tasks/LaserScanTask.hpp
@@ -11,7 +11,8 @@
 namespace rock_gazebo{
     class LaserScanTask : public LaserScanTaskBase
     {
-	friend class LaserScanTaskBase;
+        friend class LaserScanTaskBase;
+
     public:
         LaserScanTask(std::string const& name = "rock_gazebo::LaserScanTask");
         LaserScanTask(std::string const& name, RTT::ExecutionEngine* engine);
@@ -24,10 +25,10 @@ namespace rock_gazebo{
         void stopHook();
         void cleanupHook();
 
-
     private:
         void readInput( ConstLaserScanStampedPtr &laserScanMSG );
-        std::vector<base::samples::LaserScan> scans;
+        bool hasNewSample;
+        base::samples::LaserScan scan;
     };
 }
 

--- a/tasks/SensorTask.cpp
+++ b/tasks/SensorTask.cpp
@@ -38,6 +38,9 @@ bool SensorTask::configureHook()
     node = gazebo::transport::NodePtr( new gazebo::transport::Node() );
     node->Init();
 
+    gazebo::sensors::SensorPtr sensor = gazebo::sensors::get_sensor(sensorFullName);
+    sensor->SetActive(false);
+
     return true;
 }
 bool SensorTask::startHook()


### PR DESCRIPTION
This fixes two bad behaviors for some of the sensors: bad rates (lost
and/or repeated samples) and samples being sent outside of the task's
RUNNING state.

I tried to apply the same implementation pattern in all sensors, that
is avoiding to go through the updateHook, instead sending samples
straight from the callback. This is due to the (unfortunate) Gazebo
choice of using an asynchronous transport for sensors. Because of this
, the sensor samples arrive at (more or less) the right global rate,
but some jitter in logical time. In other words, one could easily receive
more than one sample in a given simulation cycle.

The mitigation used so far was to use a vector to transmit samples from
the callback to the updateHook, which is quite inefficient. Writing on
ports can be done from any thread, so do it from the callback instead.