### PR TITLE
fix: wait for sensors to initialize in SensorTask::configureHook

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -9,6 +9,7 @@
   <maintainer>Sylvain Joyeux/sylvain.joyeux@tidewise.io</maintainer>
   <license>LGPLv2 or later</license>
   <depend package="base/cmake" />
+  <depend package="base/logging" />
   <depend package="base/orogen/types" />
   <depend package="simulation/gazebo" />
   <depend package="simulation/gazebo_thruster" />

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,11 +1,13 @@
 <package>
   <description brief="Rock components needed for the rock-gazebo bridge">
-  This oroGen project defines components that are needed for the rock-gazebo bridge. They are not meant to be used standalone: the simulation/rock_gazebo package uses them to expose gazebo simulations to a Rock system
+  This oroGen project defines components that are needed for the rock-gazebo
+  bridge. They are not meant to be used standalone: the simulation/rock_gazebo
+  package uses them to expose gazebo simulations to a Rock system
   </description>
   <author>Thomio Watanabe/thomio.watanabe@fieb.org.br</author>
-  <license></license>
-  <url>http://</url>
-  <logo>http://</logo>
+  <author>Sylvain Joyeux/sylvain.joyeux@tidewise.io</author>
+  <maintainer>Sylvain Joyeux/sylvain.joyeux@tidewise.io</maintainer>
+  <license>LGPLv2 or later</license>
   <depend package="base/cmake" />
   <depend package="base/orogen/types" />
   <depend package="simulation/gazebo" />

--- a/rock_gazebo.orogen
+++ b/rock_gazebo.orogen
@@ -5,6 +5,7 @@ import_types_from 'base'
 import_types_from 'rock_gazeboTypes.hpp'
 import_types_from 'gps_base'
 
+using_library 'base-logging'
 using_library 'gazebo'
 using_library 'gazebo_thruster'
 

--- a/tasks/SensorTask.cpp
+++ b/tasks/SensorTask.cpp
@@ -39,6 +39,16 @@ bool SensorTask::configureHook()
     node = gazebo::transport::NodePtr( new gazebo::transport::Node() );
     node->Init();
 
+    int attempt = 0;
+    while (!world->SensorsInitialized()) {
+        LOG_WARN_S << "waiting for sensors to initialize" << std::endl;
+        usleep(100000);
+        if (++attempt > 100) {
+            LOG_ERROR_S << "sensors did not initialize" << std::endl;
+            return false;
+        }
+    }
+
     mSensor = gazebo::sensors::get_sensor(sensorFullName);
     if (!mSensor) {
         LOG_ERROR_S << "no sensor named " << sensorFullName << " can be found"

--- a/tasks/SensorTask.cpp
+++ b/tasks/SensorTask.cpp
@@ -5,6 +5,7 @@
 #include <gazebo/sensors/sensors.hh>
 #include <sdf/sdf.hh>
 #include <regex>
+#include <base-logging/Logging.hpp>
 
 using namespace rock_gazebo;
 using namespace std;
@@ -38,8 +39,13 @@ bool SensorTask::configureHook()
     node = gazebo::transport::NodePtr( new gazebo::transport::Node() );
     node->Init();
 
-    gazebo::sensors::SensorPtr sensor = gazebo::sensors::get_sensor(sensorFullName);
-    sensor->SetActive(false);
+    mSensor = gazebo::sensors::get_sensor(sensorFullName);
+    if (!mSensor) {
+        LOG_ERROR_S << "no sensor named " << sensorFullName << " can be found"
+                    << std::endl;
+        return false;
+    }
+    mSensor->SetActive(false);
 
     return true;
 }
@@ -47,8 +53,7 @@ bool SensorTask::startHook()
 {
     if (! SensorTaskBase::startHook())
         return false;
-    gazebo::sensors::SensorPtr sensor = gazebo::sensors::get_sensor(sensorFullName);
-    sensor->SetActive(true);
+    mSensor->SetActive(true);
     return true;
 }
 void SensorTask::updateHook()
@@ -61,8 +66,7 @@ void SensorTask::errorHook()
 }
 void SensorTask::stopHook()
 {
-    gazebo::sensors::SensorPtr sensor = gazebo::sensors::get_sensor(sensorFullName);
-    sensor->SetActive(false);
+    mSensor->SetActive(false);
     SensorTaskBase::stopHook();
 }
 void SensorTask::cleanupHook()

--- a/tasks/SensorTask.hpp
+++ b/tasks/SensorTask.hpp
@@ -4,6 +4,7 @@
 #define ROCK_GAZEBO_SENSORTASK_TASK_HPP
 
 #include "rock_gazebo/SensorTaskBase.hpp"
+#include <gazebo/sensors/sensors.hh>
 #include <gazebo/transport/Node.hh>
 
 namespace rock_gazebo{
@@ -12,7 +13,7 @@ namespace rock_gazebo{
      * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
      * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
      * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
-     * 
+     *
      * \details
      * The name of a TaskContext is primarily defined via:
      \verbatim
@@ -26,8 +27,7 @@ namespace rock_gazebo{
     {
 	friend class SensorTaskBase;
     protected:
-
-
+        gazebo::sensors::SensorPtr mSensor;
 
     public:
         /** TaskContext constructor for SensorTask
@@ -39,7 +39,7 @@ namespace rock_gazebo{
         /** TaskContext constructor for SensorTask
          * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices.
          * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task.
-         * 
+         *
          */
         SensorTask(std::string const& name, RTT::ExecutionEngine* engine);
 


### PR DESCRIPTION
I have had random crashes in simulation/rock_gazebo's test suite, while configuring some sensor task
(often a GPSTask). Finally managed to investigate and reproduce, and it turns out that the sensor itself
was null in configureHook.

Gazebo initializes sensors asynchronously, and it is not guaranteed that it is initialized when we call
configure(). Add an explicit synchronization point in configureHook, which is also what Gazebo itself does
before it initialized model plugins.