### PR TITLE
fix: no longer expect that the joint name is a scoped name

### DIFF
--- a/tasks/ModelTask.cpp
+++ b/tasks/ModelTask.cpp
@@ -121,10 +121,9 @@ void ModelTask::setupJoints()
             string joint_name = gz_joint_name.substr(prefix.size(), std::string::npos);
 
             auto gz_joint = model->GetJoint(gz_joint_name);
-            if (!gz_joint || gz_joint->GetScopedName() != gz_joint_name) {
+            if (!gz_joint) {
                 gzthrow("ModelTask: cannot find joint " << gz_joint_name
-                        << " requested in export, ModelTask expects a scoped name "
-                        << "(i.e. including the enclosing model's name)");
+                                                        << " requested in export");
             }
             else if (gz_joint->HasType(physics::Base::FIXED_JOINT)) {
                 gzthrow("ModelTask: requesting to export joint "


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-gazebo/simulation-rock_gazebo/pull/49

Expecting that the user always input a scoped name increases complexity on the robot integration side. If a robot is present in multiple gazebo worlds, and some of these world have different scopes, one would have to explicitly change the joint_names for each of these scopes, e.g.:

```
robot_with_payload -> with a joint name robot_with_payload::robot::joint
standalone_robot -> with a joint name robot::joint
```

This would allow users to use a relative names when exporting a joint, which might cause multiple exports of a joint. But then, the previous version also allows this but with a scoped name...